### PR TITLE
Fixed link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A repo built for the purpose of benchmarking the performance of agents far and w
 <img width="733" alt="Screenshot 2023-07-25 at 10 35 01 AM" src="https://github.com/Significant-Gravitas/Auto-GPT-Benchmarks/assets/9652976/98963e0b-18b9-4b17-9a6a-4d3e4418af70">
 
 ## Ranking overall:
-- 1- [Beebot](https://github.com/Significant-Gravitas/Auto-GPT)
+- 1- [Beebot](https://github.com/AutoPackAI/beebot)
 - 2- [mini-agi](https://github.com/muellerberndt/mini-agi)
 - 3- [Auto-GPT](https://github.com/Significant-Gravitas/Auto-GPT)
 ## Detailed results:


### PR DESCRIPTION
Fixed the beebot link.

### Background

The Beebot link in the README.md was pointing towards Auto-GPT.

### Changes

Modified the Beebot link URL to https://github.com/AutoPackAI/beebot

### PR Quality Checklist

- [ ] I have run the following commands against my code to ensure it passes our linters:
  ```shell
  black . --exclude test.py
  isort .
  mypy .
  autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring --in-place agbenchmark
  ```
